### PR TITLE
feat: SakeApp prebuilt binary

### DIFF
--- a/.zed/settings.json
+++ b/.zed/settings.json
@@ -3,7 +3,8 @@
     "Swift": {
       "formatter": {
         "external": {
-          "command": "swiftformat"
+          "command": "swiftformat",
+          "arguments": ["--stdinpath", "{buffer_path}"]
         }
       }
     }

--- a/.zed/tasks.json
+++ b/.zed/tasks.json
@@ -25,5 +25,14 @@
     "reveal": "always",
     "hide": "never",
     "shell": "system"
+  },
+  {
+    "label": "Format",
+    "command": "sake format",
+    "use_new_terminal": false,
+    "allow_concurrent_runs": false,
+    "reveal": "always",
+    "hide": "never",
+    "shell": "system"
   }
 ]

--- a/.zed/tasks.json
+++ b/.zed/tasks.json
@@ -9,6 +9,15 @@
     "shell": "system"
   },
   {
+    "label": "Build for tests",
+    "command": "swift build --build-tests",
+    "use_new_terminal": false,
+    "allow_concurrent_runs": false,
+    "reveal": "always",
+    "hide": "never",
+    "shell": "system"
+  },
+  {
     "label": "Unit Tests",
     "command": "sake unit_tests",
     "use_new_terminal": false,

--- a/Sources/SakeCLI/BuildCommand.swift
+++ b/Sources/SakeCLI/BuildCommand.swift
@@ -11,13 +11,21 @@ struct BuildCommand: ParsableCommand {
     @OptionGroup
     var options: CommonOptions
 
+    @Flag(name: .long, help: "Print the path to the built SakeApp executable.")
+    var showBinPath: Bool = false
+
     func run() throws {
         do {
             let configManager = ConfigManager(cliConfig: CLIConfig(commonOptions: options, commandRelatedOptions: nil))
             let config = try configManager.resolvedConfig()
 
             let manager = SakeAppManager.default(sakeAppPath: config.sakeAppPath)
-            try manager.buildSakeAppExecutable()
+            if showBinPath {
+                let binPath = try manager.getExecutablePath()
+                print(binPath)
+            } else {
+                try manager.buildSakeAppExecutable()
+            }
         } catch {
             logError(error.localizedDescription)
             BuildCommand.exit(withError: ExitCode.failure)

--- a/Sources/SakeCLI/CommonOptions.swift
+++ b/Sources/SakeCLI/CommonOptions.swift
@@ -18,6 +18,13 @@ struct CommonOptions: ParsableArguments {
 }
 
 struct CommandRelatedCommonOptions: ParsableArguments {
+    @Option(
+        name: [.long, .customShort("b")],
+        help: "Specify the path to the prebuilt SakeApp binary.\nThis is used to share the ready to use binary and avoid build process (between CI runs for example).",
+        completion: .file()
+    )
+    var sakeAppPrebuiltBinaryPath: String?
+
     @Option(name: .long, help: "Specify the strategy for converting command names' case.")
     var caseConvertingStrategy: CaseConvertingStrategy?
 }

--- a/Sources/SakeCLI/Config/CLIConfig.swift
+++ b/Sources/SakeCLI/Config/CLIConfig.swift
@@ -3,17 +3,25 @@ import SakeShared
 struct CLIConfig {
     let configPath: String?
     let sakeAppPath: String?
+    let sakeAppPrebuiltBinaryPath: String?
     let caseConvertingStrategy: CaseConvertingStrategy?
 
     init(commonOptions: CommonOptions, commandRelatedOptions: CommandRelatedCommonOptions?) {
         configPath = commonOptions.configPath
         sakeAppPath = commonOptions.sakeAppPath
+        sakeAppPrebuiltBinaryPath = commandRelatedOptions?.sakeAppPrebuiltBinaryPath
         caseConvertingStrategy = commandRelatedOptions?.caseConvertingStrategy
     }
 
-    private init(configPath: String?, sakeAppPath: String?, caseConvertingStrategy: CaseConvertingStrategy?) {
+    private init(
+        configPath: String?,
+        sakeAppPath: String?,
+        sakeAppPrebuiltBinaryPath: String?,
+        caseConvertingStrategy: CaseConvertingStrategy?
+    ) {
         self.configPath = configPath
         self.sakeAppPath = sakeAppPath
+        self.sakeAppPrebuiltBinaryPath = sakeAppPrebuiltBinaryPath
         self.caseConvertingStrategy = caseConvertingStrategy
     }
 }
@@ -22,8 +30,14 @@ extension CLIConfig {
     static func mock(
         configPath: String? = nil,
         sakeAppPath: String? = nil,
+        sakeAppPrebuiltBinaryPath: String? = nil,
         caseConvertingStrategy: CaseConvertingStrategy? = nil
     ) -> CLIConfig {
-        CLIConfig(configPath: configPath, sakeAppPath: sakeAppPath, caseConvertingStrategy: caseConvertingStrategy)
+        CLIConfig(
+            configPath: configPath,
+            sakeAppPath: sakeAppPath,
+            sakeAppPrebuiltBinaryPath: sakeAppPrebuiltBinaryPath,
+            caseConvertingStrategy: caseConvertingStrategy
+        )
     }
 }

--- a/Sources/SakeCLI/Config/Config.swift
+++ b/Sources/SakeCLI/Config/Config.swift
@@ -5,6 +5,7 @@ import SakeShared
 struct Config {
     let configPath: String
     let sakeAppPath: String
+    let sakeAppPrebuiltBinaryPath: String?
     let caseConvertingStrategy: CaseConvertingStrategy
 }
 
@@ -12,6 +13,7 @@ extension Config {
     static let `default` = Config(
         configPath: FileManager.default.currentDirectoryPath + "/.sake.yml",
         sakeAppPath: FileManager.default.currentDirectoryPath + "/SakeApp",
+        sakeAppPrebuiltBinaryPath: nil,
         caseConvertingStrategy: CaseConvertingStrategy.keepOriginal
     )
 }

--- a/Sources/SakeCLI/Config/ENVConfig.swift
+++ b/Sources/SakeCLI/Config/ENVConfig.swift
@@ -4,18 +4,26 @@ import SakeShared
 struct ENVConfig {
     let configPath: String?
     let sakeAppPath: String?
+    let sakeAppPrebuiltBinaryPath: String?
     let caseConvertingStrategy: CaseConvertingStrategy?
 
     init() {
         configPath = ProcessInfo.processInfo.environment["SAKE_CONFIG_PATH"]
         sakeAppPath = ProcessInfo.processInfo.environment["SAKE_APP_PATH"]
+        sakeAppPrebuiltBinaryPath = ProcessInfo.processInfo.environment["SAKE_APP_PREBUILT_BINARY_PATH"]
         caseConvertingStrategy = ProcessInfo.processInfo.environment["SAKE_CASE_CONVERTING_STRATEGY"]
             .flatMap(CaseConvertingStrategy.init(rawValue:))
     }
 
-    private init(configPath: String?, sakeAppPath: String?, caseConvertingStrategy: CaseConvertingStrategy?) {
+    private init(
+        configPath: String?,
+        sakeAppPath: String?,
+        sakeAppPrebuiltBinaryPath: String?,
+        caseConvertingStrategy: CaseConvertingStrategy?
+    ) {
         self.configPath = configPath
         self.sakeAppPath = sakeAppPath
+        self.sakeAppPrebuiltBinaryPath = sakeAppPrebuiltBinaryPath
         self.caseConvertingStrategy = caseConvertingStrategy
     }
 }
@@ -24,8 +32,14 @@ extension ENVConfig {
     static func mock(
         configPath: String? = nil,
         sakeAppPath: String? = nil,
+        sakeAppPrebuiltBinaryPath: String? = nil,
         caseConvertingStrategy: CaseConvertingStrategy? = nil
     ) -> ENVConfig {
-        ENVConfig(configPath: configPath, sakeAppPath: sakeAppPath, caseConvertingStrategy: caseConvertingStrategy)
+        ENVConfig(
+            configPath: configPath,
+            sakeAppPath: sakeAppPath,
+            sakeAppPrebuiltBinaryPath: sakeAppPrebuiltBinaryPath,
+            caseConvertingStrategy: caseConvertingStrategy
+        )
     }
 }

--- a/Sources/SakeCLI/Config/FileConfig.swift
+++ b/Sources/SakeCLI/Config/FileConfig.swift
@@ -4,17 +4,27 @@ import Yams
 
 struct FileConfig: Decodable {
     let sakeAppPath: String?
+    let sakeAppPrebuiltBinaryPath: String?
     let caseConvertingStrategy: CaseConvertingStrategy?
 
     enum CodingKeys: String, CodingKey {
         case sakeAppPath = "sake_app_path"
+        case sakeAppPrebuiltBinaryPath = "sake_app_prebuilt_binary_path"
         case caseConvertingStrategy = "case_converting_strategy"
     }
 }
 
 extension FileConfig {
-    static func mock(sakeAppPath: String? = nil, caseConvertingStrategy: CaseConvertingStrategy? = nil) -> FileConfig {
-        FileConfig(sakeAppPath: sakeAppPath, caseConvertingStrategy: caseConvertingStrategy)
+    static func mock(
+        sakeAppPath: String? = nil,
+        sakeAppPrebuiltBinaryPath: String? = nil,
+        caseConvertingStrategy: CaseConvertingStrategy? = nil
+    ) -> FileConfig {
+        FileConfig(
+            sakeAppPath: sakeAppPath,
+            sakeAppPrebuiltBinaryPath: sakeAppPrebuiltBinaryPath,
+            caseConvertingStrategy: caseConvertingStrategy
+        )
     }
 }
 

--- a/Sources/SakeCLI/ListCommand.swift
+++ b/Sources/SakeCLI/ListCommand.swift
@@ -24,7 +24,11 @@ struct ListCommand: ParsableCommand {
             let config = try configManager.resolvedConfig()
 
             let manager = SakeAppManager.default(sakeAppPath: config.sakeAppPath)
-            try manager.listAvailableCommands(caseConvertingStrategy: config.caseConvertingStrategy, json: json)
+            try manager.listAvailableCommands(
+                prebuiltExecutablePath: config.sakeAppPrebuiltBinaryPath,
+                caseConvertingStrategy: config.caseConvertingStrategy,
+                json: json
+            )
         } catch {
             if case let SakeAppManager.Error.sakeAppError(sakeAppError) = error {
                 // log only unexpected errors, business errors are already pretty logged by the SakeApp

--- a/Sources/SakeCLI/RunCommand.swift
+++ b/Sources/SakeCLI/RunCommand.swift
@@ -29,7 +29,12 @@ struct RunCommand: ParsableCommand {
             let config = try configManager.resolvedConfig()
 
             let manager = SakeAppManager.default(sakeAppPath: config.sakeAppPath)
-            try manager.run(command: command, args: args, caseConvertingStrategy: config.caseConvertingStrategy)
+            try manager.run(
+                prebuiltExecutablePath: config.sakeAppPrebuiltBinaryPath,
+                command: command,
+                args: args,
+                caseConvertingStrategy: config.caseConvertingStrategy
+            )
         } catch {
             if case let SakeAppManager.Error.sakeAppError(sakeAppError) = error {
                 // log only unexpected errors, business errors are already pretty logged by the SakeApp

--- a/Sources/SakeCLI/SakeAppManager/SakeAppManage+LocalizedError.swift
+++ b/Sources/SakeCLI/SakeAppManager/SakeAppManage+LocalizedError.swift
@@ -4,6 +4,7 @@ extension SakeAppManager {
     enum Error: Swift.Error {
         case sakeAppAlreadyInitialized(path: String)
         case sakeAppNotValid(ValidationError)
+        case sakeAppPrebuiltBinaryNotFound(path: String)
 
         case failedToReadSwiftVersion(stdout: String, stderr: String)
         case failedToCleanSakeApp(stdout: String, stderr: String)
@@ -69,6 +70,8 @@ extension SakeAppManager.Error: LocalizedError {
             "SakeApp already initialized at \(path)."
         case let .sakeAppNotValid(error):
             "SakeApp is not valid. Error: \(error.localizedDescription)"
+        case let .sakeAppPrebuiltBinaryNotFound(path):
+            "SakeApp prebuilt binary not found at \(path)."
         case let .failedToReadSwiftVersion(stdout, stderr):
             """
             Failed to read the Swift version.

--- a/Sources/SakeCLI/SakeAppManager/SakeAppManager+FileHandle.swift
+++ b/Sources/SakeCLI/SakeAppManager/SakeAppManager+FileHandle.swift
@@ -11,6 +11,8 @@ extension SakeAppManager {
         func validatePackageSwiftExists() throws
         func isExecutableOlderThenSourceFiles(executablePath: String) throws -> Bool
 
+        func isPrebuiltExecutableExists(path: String) -> Bool
+
         func getSavedSwiftVersionDump(binPath: String) throws -> String?
         func saveSwiftVersionDump(binPath: String, dump: String) throws
     }
@@ -97,6 +99,10 @@ extension SakeAppManager {
             }
 
             return false
+        }
+
+        func isPrebuiltExecutableExists(path: String) -> Bool {
+            FileManager.default.fileExists(atPath: path)
         }
 
         func getSavedSwiftVersionDump(binPath: String) throws -> String? {

--- a/Sources/SakeCLI/SakeAppManager/SakeAppManager.swift
+++ b/Sources/SakeCLI/SakeAppManager/SakeAppManager.swift
@@ -69,8 +69,8 @@ final class SakeAppManager {
         }
     }
 
-    func run(command: String, args: [String], caseConvertingStrategy: CaseConvertingStrategy) throws {
-        let executablePath = try buildSakeAppExecutableIfNeeded()
+    func run(prebuiltExecutablePath: String?, command: String, args: [String], caseConvertingStrategy: CaseConvertingStrategy) throws {
+        let executablePath = try getPrebuiltBinaryIfExistsyOrBuildFromSource(prebuiltExecutablePath: prebuiltExecutablePath)
         try commandExecutor.callRunCommandOnExecutable(
             executablePath: executablePath,
             command: command,
@@ -79,13 +79,25 @@ final class SakeAppManager {
         )
     }
 
-    func listAvailableCommands(caseConvertingStrategy: CaseConvertingStrategy, json: Bool) throws {
-        let executablePath = try buildSakeAppExecutableIfNeeded()
+    func listAvailableCommands(prebuiltExecutablePath: String?, caseConvertingStrategy: CaseConvertingStrategy, json: Bool) throws {
+        let executablePath = try getPrebuiltBinaryIfExistsyOrBuildFromSource(prebuiltExecutablePath: prebuiltExecutablePath)
         try commandExecutor.callListCommandOnExecutable(
             executablePath: executablePath,
             json: json,
             caseConvertingStrategy: caseConvertingStrategy
         )
+    }
+
+    private func getPrebuiltBinaryIfExistsyOrBuildFromSource(prebuiltExecutablePath: String?) throws -> String {
+        if let prebuiltExecutablePath {
+            if fileHandle.isPrebuiltExecutableExists(path: prebuiltExecutablePath) {
+                return prebuiltExecutablePath
+            } else {
+                throw Error.sakeAppPrebuiltBinaryNotFound(path: prebuiltExecutablePath)
+            }
+        } else {
+            return try buildSakeAppExecutableIfNeeded()
+        }
     }
 
     @discardableResult

--- a/Tests/SakeCLITests/ConfigResolverTests.swift
+++ b/Tests/SakeCLITests/ConfigResolverTests.swift
@@ -46,10 +46,38 @@ final class ConfigResolverTests: XCTestCase {
 
     // MARK: - resolve
 
+    func testResolveShoultThrowErrorIfDefinedMutualExclusiveOptions() throws {
+        let resolver = ConfigResolver()
+
+        XCTAssertThrowsError(try resolver.resolve(
+            cliConfig: .mock(sakeAppPath: "cli-sourced-path", sakeAppPrebuiltBinaryPath: "cli-sourced-path"),
+            envConfig: .mock(sakeAppPath: nil, sakeAppPrebuiltBinaryPath: nil),
+            fileConfig: .mock(sakeAppPath: nil, sakeAppPrebuiltBinaryPath: nil)
+        )) { error in
+            XCTAssertEqual(error as? ConfigResolver.Error, .mutualExclusiveOptions(["sakeAppPath", "sakeAppPrebuiltBinaryPath"]))
+        }
+
+        XCTAssertThrowsError(try resolver.resolve(
+            cliConfig: .mock(sakeAppPath: "cli-sourced-path", sakeAppPrebuiltBinaryPath: nil),
+            envConfig: .mock(sakeAppPath: nil, sakeAppPrebuiltBinaryPath: "cli-sourced-path"),
+            fileConfig: .mock(sakeAppPath: nil, sakeAppPrebuiltBinaryPath: nil)
+        )) { error in
+            XCTAssertEqual(error as? ConfigResolver.Error, .mutualExclusiveOptions(["sakeAppPath", "sakeAppPrebuiltBinaryPath"]))
+        }
+
+        XCTAssertThrowsError(try resolver.resolve(
+            cliConfig: .mock(sakeAppPath: "cli-sourced-path", sakeAppPrebuiltBinaryPath: nil),
+            envConfig: .mock(sakeAppPath: nil, sakeAppPrebuiltBinaryPath: nil),
+            fileConfig: .mock(sakeAppPath: nil, sakeAppPrebuiltBinaryPath: "cli-sourced-path")
+        )) { error in
+            XCTAssertEqual(error as? ConfigResolver.Error, .mutualExclusiveOptions(["sakeAppPath", "sakeAppPrebuiltBinaryPath"]))
+        }
+    }
+
     func testConfigShouldResolvedByDefaultValueIfNothingElsePassed() throws {
         let resolver = ConfigResolver()
 
-        let resolvedConfig = resolver.resolve(
+        let resolvedConfig = try resolver.resolve(
             cliConfig: .mock(configPath: nil, sakeAppPath: nil, caseConvertingStrategy: nil),
             envConfig: .mock(configPath: nil, sakeAppPath: nil, caseConvertingStrategy: nil),
             fileConfig: nil
@@ -62,7 +90,7 @@ final class ConfigResolverTests: XCTestCase {
     func testConfigShouldResolvedByEnvVarIfPassed() throws {
         let resolver = ConfigResolver()
 
-        let resolvedConfig = resolver.resolve(
+        let resolvedConfig = try resolver.resolve(
             cliConfig: .mock(configPath: nil, sakeAppPath: nil, caseConvertingStrategy: nil),
             envConfig: .mock(configPath: "env-sourced-path", sakeAppPath: "env-sourced-path-2", caseConvertingStrategy: .toKebabCase),
             fileConfig: nil
@@ -75,7 +103,7 @@ final class ConfigResolverTests: XCTestCase {
     func testConfigShouldResolvedByCliIfPassed() throws {
         let resolver = ConfigResolver()
 
-        let resolvedConfig = resolver.resolve(
+        let resolvedConfig = try resolver.resolve(
             cliConfig: .mock(configPath: "cli-sourced-path", sakeAppPath: "cli-sourced-path-2", caseConvertingStrategy: .toSnakeCase),
             envConfig: .mock(configPath: nil, sakeAppPath: nil, caseConvertingStrategy: nil),
             fileConfig: nil
@@ -88,7 +116,7 @@ final class ConfigResolverTests: XCTestCase {
     func testConfigShouldResolvedByFileConfigIfPassed() throws {
         let resolver = ConfigResolver()
 
-        let resolvedConfig = resolver.resolve(
+        let resolvedConfig = try resolver.resolve(
             cliConfig: .mock(configPath: nil, sakeAppPath: nil, caseConvertingStrategy: nil),
             envConfig: .mock(configPath: nil, sakeAppPath: nil, caseConvertingStrategy: nil),
             fileConfig: .mock(sakeAppPath: "file-sourced-path", caseConvertingStrategy: nil)
@@ -101,7 +129,7 @@ final class ConfigResolverTests: XCTestCase {
     func testConfigShouldResolvedByCliEvenIfEnvVarIsPassed() throws {
         let resolver = ConfigResolver()
 
-        let resolvedConfig = resolver.resolve(
+        let resolvedConfig = try resolver.resolve(
             cliConfig: .mock(configPath: "cli-sourced-path", sakeAppPath: "cli-sourced-path-2", caseConvertingStrategy: .toSnakeCase),
             envConfig: .mock(configPath: "env-sourced-path", sakeAppPath: "env-sourced-path-2", caseConvertingStrategy: .toKebabCase),
             fileConfig: nil
@@ -114,7 +142,7 @@ final class ConfigResolverTests: XCTestCase {
     func testConfigShouldResolvedByCliIfFileConfigIsPassed() throws {
         let resolver = ConfigResolver()
 
-        let resolvedConfig = resolver.resolve(
+        let resolvedConfig = try resolver.resolve(
             cliConfig: .mock(configPath: "cli-sourced-path", sakeAppPath: "cli-sourced-path-2", caseConvertingStrategy: .toSnakeCase),
             envConfig: .mock(configPath: nil, sakeAppPath: nil, caseConvertingStrategy: nil),
             fileConfig: .mock(sakeAppPath: "file-sourced-path", caseConvertingStrategy: nil)
@@ -127,7 +155,7 @@ final class ConfigResolverTests: XCTestCase {
     func testConfigShouldResolvedByEnvVarIfFileConfigIsPassed() throws {
         let resolver = ConfigResolver()
 
-        let resolvedConfig = resolver.resolve(
+        let resolvedConfig = try resolver.resolve(
             cliConfig: .mock(configPath: nil, sakeAppPath: nil, caseConvertingStrategy: nil),
             envConfig: .mock(configPath: "env-sourced-path", sakeAppPath: "env-sourced-path-2", caseConvertingStrategy: .toKebabCase),
             fileConfig: .mock(sakeAppPath: "file-sourced-path", caseConvertingStrategy: nil)
@@ -140,7 +168,7 @@ final class ConfigResolverTests: XCTestCase {
     func testConfigShouldResolvedByCliConfigIfFileAndEnvVarArePassed() throws {
         let resolver = ConfigResolver()
 
-        let resolvedConfig = resolver.resolve(
+        let resolvedConfig = try resolver.resolve(
             cliConfig: .mock(configPath: "cli-sourced-path", sakeAppPath: "cli-sourced-path-2", caseConvertingStrategy: .toSnakeCase),
             envConfig: .mock(configPath: "env-sourced-path", sakeAppPath: "env-sourced-path-2", caseConvertingStrategy: .toKebabCase),
             fileConfig: .mock(sakeAppPath: "file-sourced-path", caseConvertingStrategy: nil)


### PR DESCRIPTION
New Feature: Prebuilt SakeApp Binary

This feature allows you to build the SakeApp, retrieve its path, and save the prebuilt binary for future reuse. It’s particularly useful for CI workflows, where avoiding repeated builds can save time and resources.