### PR TITLE
feat: resolve SakeApp path by search in parent dirs if specified not exists

### DIFF
--- a/Sources/SakeCLI/SakeAppManager/SakeAppManager.swift
+++ b/Sources/SakeCLI/SakeAppManager/SakeAppManager.swift
@@ -21,23 +21,6 @@ enum InitializedMode {}
 // MARK: - Factory methods
 
 extension SakeAppManager {
-    static func makeInUninitializedMode(sakeAppPath: String) -> SakeAppManager<UninitializedMode> {
-        .makeDefault(sakeAppPath: sakeAppPath)
-    }
-
-    static func makeInInitializedMode(sakeAppPath: String) throws -> SakeAppManager<InitializedMode> {
-        try validateSakeAppIsExists(sakeAppPath: sakeAppPath)
-        return .makeDefault(sakeAppPath: sakeAppPath)
-    }
-
-    private static func validateSakeAppIsExists(sakeAppPath: String) throws {
-        let fileManager = FileManager.default
-        var isDirectory: ObjCBool = false
-        guard fileManager.fileExists(atPath: sakeAppPath, isDirectory: &isDirectory), isDirectory.boolValue else {
-            throw SakeAppManagerError.sakeAppNotInitialized(path: sakeAppPath)
-        }
-    }
-
     private static func makeDefault(sakeAppPath: String) -> Self {
         let fileHandle = DefaultSakeAppManagerFileHandle(path: sakeAppPath)
         let processMonitor = ProcessMonitor()
@@ -45,5 +28,55 @@ extension SakeAppManager {
         let shellExecutor = ShellExecutor(processMonitor: processMonitor)
         let commandExecutor = DefaultSakeAppManagerCommandExecutor(fileHandle: fileHandle, shellExecutor: shellExecutor)
         return Self(fileHandle: fileHandle, commandExecutor: commandExecutor)
+    }
+}
+
+// MARK: Uninitialized mode
+
+extension SakeAppManager {
+    static func makeInUninitializedMode(sakeAppPath: String) -> SakeAppManager<UninitializedMode> {
+        .makeDefault(sakeAppPath: sakeAppPath)
+    }
+}
+
+// MARK: Initialized mode
+
+extension SakeAppManager {
+    static func makeInInitializedMode(sakeAppPath: String) throws -> SakeAppManager<InitializedMode> {
+        let sakeAppPath = try processSakeAppPath(sakeAppPath)
+        return .makeDefault(sakeAppPath: sakeAppPath)
+    }
+
+    private static func processSakeAppPath(_ path: String) throws -> String {
+        let standartizedPath = URL(fileURLWithPath: path).standardizedFileURL.path
+        var isDirectory: ObjCBool = false
+        if FileManager.default.fileExists(atPath: standartizedPath, isDirectory: &isDirectory), isDirectory.boolValue {
+            return standartizedPath
+        } else if let nearestSakeApp = Self.findNearestProjectDirectory(from: standartizedPath) {
+            log("SakeApp not found at \(standartizedPath). Using nearest SakeApp at \(nearestSakeApp).")
+            return nearestSakeApp
+        } else {
+            throw SakeAppManagerError.sakeAppNotInitialized(path: path)
+        }
+    }
+
+    private static func findNearestProjectDirectory(from path: String) -> String? {
+        let defaultAppDirectoryName = "SakeApp"
+        var currentPath = path
+        while currentPath != "/" {
+            let contents = try? FileManager.default.contentsOfDirectory(atPath: currentPath)
+            if contents?.contains(defaultAppDirectoryName) == true {
+                let sakeAppDirectoryCandidate = currentPath + "/" + defaultAppDirectoryName
+                var isDirectory: ObjCBool = false
+                guard FileManager.default.fileExists(atPath: sakeAppDirectoryCandidate, isDirectory: &isDirectory),
+                      isDirectory.boolValue
+                else {
+                    continue
+                }
+                return sakeAppDirectoryCandidate
+            }
+            currentPath = URL(fileURLWithPath: currentPath).deletingLastPathComponent().path
+        }
+        return nil
     }
 }

--- a/Tests/SakeCLITests/SakeAppManagerTests.swift
+++ b/Tests/SakeCLITests/SakeAppManagerTests.swift
@@ -19,7 +19,7 @@ final class SakeAppManagerTests: XCTestCase {
     // MARK: - Factory methods
 
     func testSakeAppManager_inInitializedMode_shouldNotInitialize_ifSakeAppDirectoryDoesNotExists() throws {
-        XCTAssertThrowsError(try SakeAppManager<InitializedMode>.makeInInitializedMode(sakeAppPath: "jepa")) { error in
+        XCTAssertThrowsError(try SakeAppManager<InitializedMode>.makeInInitializedMode(sakeAppPath: "/jepa/nonexistent/dir")) { error in
             let sakeAppManagerError = error as! SakeAppManagerError
             if case .sakeAppNotInitialized = sakeAppManagerError {
                 XCTAssertTrue(true)
@@ -27,6 +27,17 @@ final class SakeAppManagerTests: XCTestCase {
                 XCTFail("Unexpected error: \(sakeAppManagerError)")
             }
         }
+    }
+
+    func testSakeAppManager_inInitializedMode_shouldInitializeByParentSakeAppDirectory_ifSpecifiedSakeAppDirectoryDoesNotExists() throws {
+        let tempDirectory = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString).path
+        let parentSideSakeAppDirectory = tempDirectory + "/SakeApp"
+        let specifiedSakeAppDirectory = tempDirectory + "/some/other/dir/jepa"
+
+        try FileManager.default.createDirectory(atPath: parentSideSakeAppDirectory, withIntermediateDirectories: true, attributes: nil)
+
+        let manager = try SakeAppManager<InitializedMode>.makeInInitializedMode(sakeAppPath: specifiedSakeAppDirectory)
+        XCTAssertEqual(manager.fileHandle.path, parentSideSakeAppDirectory)
     }
 
     // MARK: - Initialize


### PR DESCRIPTION
make like behavior to call sake commands from child directories
