### PR TITLE
fix: setup code coverage swift toolchain env using xcodes

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -3,7 +3,6 @@ name: Code Coverage
 on:
   push:
     branches:
-      - main
 
 jobs:
   coverage:

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -7,15 +7,15 @@ on:
 
 jobs:
   coverage:
-    runs-on: macos-latest
+    runs-on: macos-15
 
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
 
-      - uses: swift-actions/setup-swift@v2
-        with:
-          swift-version: 6.1
+      - name: Set up Xcode
+        run: |
+          xcodes select 16.3
 
       - name: Run tests with coverage
         run: |

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -3,6 +3,7 @@ name: Code Coverage
 on:
   push:
     branches:
+      - main
 
 jobs:
   coverage:


### PR DESCRIPTION
We can’t just use setup-swift because we need access to the appropriate version of llvm-cov via xcrun.